### PR TITLE
feat: 各ユースケースの出力モデルを更新

### DIFF
--- a/src/app/domain/model/task.py
+++ b/src/app/domain/model/task.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field
 
 
 class TaskStatus(Enum):
@@ -25,7 +25,3 @@ class Task(BaseModel):
         elif self.status == TaskStatus.IN_PROGRESS:
             self.status = TaskStatus.DONE
         return
-
-    @field_serializer("status")
-    def serialize_status(self, status: TaskStatus) -> str:
-        return status.value

--- a/src/app/port/inbound/i_create_task_usecase.py
+++ b/src/app/port/inbound/i_create_task_usecase.py
@@ -11,7 +11,13 @@ class CreateTaskRequest(BaseModel):
 
 
 class CreateTaskResponse(BaseModel):
-    task: Task
+    id: str
+    title: str
+    status: Literal["todo", "in_progress", "done"]
+
+    @classmethod
+    def create(cls, task: Task) -> "CreateTaskResponse":
+        return cls(id=task.id, title=task.title, status=task.status.value)
 
 
 class FailedToCreateTask(BaseModel):

--- a/src/app/port/inbound/i_progress_status_usecase.py
+++ b/src/app/port/inbound/i_progress_status_usecase.py
@@ -11,7 +11,13 @@ class ProgressStatusRequest(BaseModel):
 
 
 class ProgressStatusResponse(BaseModel):
-    task: Task
+    id: str
+    title: str
+    status: str
+
+    @classmethod
+    def create(cls, task: Task) -> "ProgressStatusResponse":
+        return cls(id=task.id, title=task.title, status=task.status.value)
 
 
 class FailedToProgressStatus(BaseModel):

--- a/src/app/port/inbound/i_show_tasks_usecase.py
+++ b/src/app/port/inbound/i_show_tasks_usecase.py
@@ -6,8 +6,22 @@ from pydantic import BaseModel
 from src.app.domain.model.task import Task
 
 
+class TaskDto(BaseModel):
+    id: str
+    title: str
+    status: Literal["todo", "in_progress", "done"]
+
+    @classmethod
+    def create(cls, task: Task) -> "TaskDto":
+        return cls(id=task.id, title=task.title, status=task.status.value)
+
+
 class ShowTasksResponse(BaseModel):
-    tasks: list[Task]
+    tasks: list[TaskDto]
+
+    @classmethod
+    def create(cls, tasks: list[Task]) -> "ShowTasksResponse":
+        return cls(tasks=[TaskDto.create(task) for task in tasks])
 
 
 class FailedToShowTasks(BaseModel):

--- a/src/app/usecase/create_task_usecase.py
+++ b/src/app/usecase/create_task_usecase.py
@@ -23,4 +23,4 @@ class CreateTaskUsecase(ICreateTaskUsecase):
     def _run(self, request: CreateTaskRequest) -> CreateTaskResponse:
         task = Task.create(title=request.title)
         self.task_repository.add(task)
-        return CreateTaskResponse(task=task)
+        return CreateTaskResponse.create(task)

--- a/src/app/usecase/progress_status_usecase.py
+++ b/src/app/usecase/progress_status_usecase.py
@@ -26,4 +26,4 @@ class ProgressStatusUsecase(IProgressStatusUsecase):
         task = self.task_repository.load_by_id(request.task_id)
         task.progress_status()
         self.task_repository.update(task)
-        return ProgressStatusResponse(task=task)
+        return ProgressStatusResponse.create(task=task)

--- a/src/app/usecase/show_tasks_usecase.py
+++ b/src/app/usecase/show_tasks_usecase.py
@@ -18,4 +18,4 @@ class ShowTasksUsecase(IShowTasksUsecase):
 
     def _run(self) -> ShowTasksResponse:
         tasks = self.task_repository.load_all()
-        return ShowTasksResponse(tasks=tasks)
+        return ShowTasksResponse.create(tasks=tasks)


### PR DESCRIPTION
This pull request introduces several changes to the task management module to improve the consistency and clarity of the task-related data models and their serialization. The most important changes include the removal of the `field_serializer` method, the introduction of new response DTOs, and updates to the use cases to utilize these DTOs.

### Removal of `field_serializer` and related methods:
* [`src/app/domain/model/task.py`](diffhunk://#diff-7c4ba5b93a9dbb2aa104350924b209d668fe0d58396c59a1b3cdbc550402b456L28-L31): Removed the `field_serializer` method for the `status` field in the `Task` model.

### Introduction of new response DTOs:
* [`src/app/port/inbound/i_create_task_usecase.py`](diffhunk://#diff-44ca44bbf3316eb4f7a20098aa072bba67516103290b0e1a48215da89422fb7aL14-R20): Modified `CreateTaskResponse` to include `id`, `title`, and `status` fields, and added a `create` class method for constructing the response from a `Task` object.
* [`src/app/port/inbound/i_progress_status_usecase.py`](diffhunk://#diff-fee8ba7f1f9e2cc365f97a22d2ced5be14539e7656de1113ccae0f11a1ab88f1L14-R20): Modified `ProgressStatusResponse` to include `id`, `title`, and `status` fields, and added a `create` class method for constructing the response from a `Task` object.
* [`src/app/port/inbound/i_show_tasks_usecase.py`](diffhunk://#diff-d5b713672ef45cc0b49a45a0717db6c3bd2dd48e2e9278dd46f38835fc7e66ddR9-R24): Introduced `TaskDto` for task representation in the `ShowTasksResponse`, and added a `create` class method for constructing the response from a list of `Task` objects.

### Updates to use cases to utilize new DTOs:
* [`src/app/usecase/create_task_usecase.py`](diffhunk://#diff-74cd83a607a21b2bf8606c59025f4e50d4275bd20d7ed5f1fb1e9df14ca3c8f4L26-R26): Updated the `CreateTaskUseCase` to return a `CreateTaskResponse` using the `create` method.
* [`src/app/usecase/progress_status_usecase.py`](diffhunk://#diff-0337a289eae507856b248b883ccc50fc73355ebc4b8dc70ff05ca7c1e8590030L29-R29): Updated the `ProgressStatusUseCase` to return a `ProgressStatusResponse` using the `create` method.
* [`src/app/usecase/show_tasks_usecase.py`](diffhunk://#diff-04cef032fa45bcdb263b318a6a7e9325cb812d31bd1a3d04f970e3c90add8b6dL21-R21): Updated the `ShowTasksUseCase` to return a `ShowTasksResponse` using the `create` method.